### PR TITLE
Remove duplicate entries in INSTALLED_APPS

### DIFF
--- a/aidai_goi/settings.py
+++ b/aidai_goi/settings.py
@@ -44,8 +44,6 @@ INSTALLED_APPS = [
     'profile_app',
     'cars',
     'rent',
-    'django.contrib.admin',
-    'django.contrib.auth',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
The `INSTALLED_APPS` setting contained duplicate entries for 

1. `'django.contrib.admin'` 
2. `'django.contrib.auth'`

which caused an `ImproperlyConfigured` error. Removed the duplicate entries.
